### PR TITLE
build: require C++14 for `std::make_unique`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(CompactNSearch)
 # Visual studio solution directories.
 set_property(GLOBAL PROPERTY USE_FOLDERS on)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if (UNIX)


### PR DESCRIPTION
This project use `std::make_unique` which is a C++14 library feature (https://en.cppreference.com/w/cpp/memory/unique_ptr/make_unique).

We should either increase the minimum required standard or use the error-prone `std::unique_ptr(new ...)` constructor.