### PR TITLE
Remove dependency on parallel stl algorithms 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS on)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-if (UNIX)
-find_package(OpenMP)
+find_package(OpenMP REQUIRED)
 if (OPENMP_FOUND)
 	if (CMAKE_VERSION VERSION_GREATER "3.8")
 		link_libraries(OpenMP::OpenMP_CXX)
@@ -17,7 +16,6 @@ if (OPENMP_FOUND)
 		set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 	endif()
 endif(OPENMP_FOUND)
-endif (UNIX)
 
 OPTION(BUILD_AS_SHARED_LIBS "Build all the libraries as shared" OFF)
 if (BUILD_AS_SHARED_LIBS)
@@ -48,11 +46,6 @@ else()
 endif ()
 
 target_include_directories(CompactNSearch PUBLIC include)
-
-if (APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-	find_package(oneDPL REQUIRED)
-	target_link_libraries(CompactNSearch PUBLIC oneDPL)
-endif()
 
 install(FILES "include/CompactNSearch" ${HEADER_FILES}
 	DESTINATION include/)

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -8,6 +8,7 @@
 #include <limits>
 #include <chrono>
 #include <random>
+#include <algorithm>
 
 #include <omp.h>
 
@@ -151,21 +152,15 @@ enright_velocity_field(std::array<Real, 3> const& x)
 void
 advect()
 {
-#ifdef _MSC_VER
-	concurrency::parallel_for_each(
-#elif defined(__APPLE__) && defined(__clang__)
-	std::for_each(oneapi::dpl::execution::par,
-#else
-	__gnu_parallel::for_each(
-#endif
-	positions.begin(), positions.end(), [&](std::array<Real, 3>& x)
+#pragma omp parallel for
+	for (int _i = 0; _i < positions.size(); _i++)
 	{
+		std::array<Real, 3>& x = positions[_i];
 		std::array<Real, 3> v = enright_velocity_field(x);
 		x[0] += static_cast<Real>(0.005) * v[0];
 		x[1] += static_cast<Real>(0.005) * v[1];
 		x[2] += static_cast<Real>(0.005) * v[1];
 	}
-	);
 }
 
 int main(int argc, char* argv[])

--- a/include/CompactNSearch.h
+++ b/include/CompactNSearch.h
@@ -4,6 +4,7 @@
 #include "DataStructures.h"
 #include "PointSet.h"
 
+#include <cmath>
 #include <unordered_map>
 
 namespace CompactNSearch

--- a/include/Config.h
+++ b/include/Config.h
@@ -11,12 +11,3 @@ namespace CompactNSearch
 
 #define INITIAL_NUMBER_OF_INDICES   50
 #define INITIAL_NUMBER_OF_NEIGHBORS 50
-
-#ifdef _MSC_VER
-	#include <ppl.h>
-#elif defined(__APPLE__) && defined(__clang__)
-	#include <oneapi/dpl/execution>
-	#include <oneapi/dpl/algorithm>
-#else
-	#include <parallel/algorithm>
-#endif

--- a/include/DataStructures.h
+++ b/include/DataStructures.h
@@ -2,6 +2,7 @@
 
 #include "Config.h"
 
+#include <algorithm>
 #include <atomic>
 #include <vector>
 

--- a/include/PointSet.h
+++ b/include/PointSet.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Config.h>
+#include <limits>
 #include <iostream>
 
 namespace CompactNSearch


### PR DESCRIPTION
Only depend on OpenMP for parallelism. This makes cross-platform compatibility a lot easier, at least for the time being.