### PR TITLE
Replace oneDPL with Dispatch on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,11 +49,6 @@ endif ()
 
 target_include_directories(CompactNSearch PUBLIC include)
 
-if (APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-	find_package(oneDPL REQUIRED)
-	target_link_libraries(CompactNSearch PUBLIC oneDPL)
-endif()
-
 install(FILES "include/CompactNSearch" ${HEADER_FILES}
 	DESTINATION include/)
 

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -154,7 +154,7 @@ advect()
 #ifdef _MSC_VER
 	concurrency::parallel_for_each(
 #elif defined(__APPLE__) && defined(__clang__)
-	std::for_each(oneapi::dpl::execution::par,
+	dispatch::parallel_for_each(
 #else
 	__gnu_parallel::for_each(
 #endif

--- a/include/Config.h
+++ b/include/Config.h
@@ -15,8 +15,23 @@ namespace CompactNSearch
 #ifdef _MSC_VER
 	#include <ppl.h>
 #elif defined(__APPLE__) && defined(__clang__)
-	#include <oneapi/dpl/execution>
-	#include <oneapi/dpl/algorithm>
+	#include <dispatch/dispatch.h>
+	#include <iterator>
+
+	namespace dispatch
+	{
+		template <typename _Iterator, typename _Function>
+		void parallel_for_each(_Iterator first, _Iterator last, const _Function& _Func)
+		{
+			dispatch_apply(
+				std::distance(first, last),
+				DISPATCH_APPLY_AUTO,
+				^(size_t i) {
+					_Func(*std::next(first, i));
+				}
+			);
+		}
+	}
 #else
 	#include <parallel/algorithm>
 #endif

--- a/src/CompactNSearch.cpp
+++ b/src/CompactNSearch.cpp
@@ -237,7 +237,7 @@ NeighborhoodSearch::update_point_sets()
 #ifdef _MSC_VER
 	concurrency::parallel_for_each(
 #elif defined(__APPLE__) && defined(__clang__)
-	std::for_each(oneapi::dpl::execution::par,
+	dispatch::parallel_for_each(
 #else
 	__gnu_parallel::for_each(
 #endif
@@ -318,7 +318,7 @@ NeighborhoodSearch::erase_empty_entries(std::vector<unsigned int> const& to_dele
 #ifdef _MSC_VER
 	concurrency::parallel_for_each(
 #elif defined(__APPLE__) && defined(__clang__)
-	std::for_each(oneapi::dpl::execution::par,
+	dispatch::parallel_for_each(
 #else
 	__gnu_parallel::for_each(
 #endif
@@ -418,7 +418,7 @@ NeighborhoodSearch::query()
 #ifdef _MSC_VER
 	concurrency::parallel_for_each(
 #elif defined(__APPLE__) && defined(__clang__)
-	std::for_each(oneapi::dpl::execution::par,
+	dispatch::parallel_for_each(
 #else
 	__gnu_parallel::for_each(
 #endif
@@ -480,7 +480,7 @@ NeighborhoodSearch::query()
 #ifdef _MSC_VER
 	concurrency::parallel_for_each(
 #elif defined(__APPLE__) && defined(__clang__)
-	std::for_each(oneapi::dpl::execution::par,
+	dispatch::parallel_for_each(
 #else
 	__gnu_parallel::for_each(
 #endif


### PR DESCRIPTION
Since oneDPL [dropped support for C++11](https://github.com/oneapi-src/oneDPL/releases/tag/oneDPL-2022.0.0-release) and [broke for recent versions of libc++](https://github.com/oneapi-src/oneDPL/issues/1602), I'd propose to remove the external dependency and use Apple's Dispatch library on macOS.

Alternatively, #10 works just as well. 🙂 